### PR TITLE
Comment out the "IP Range Assets" step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Temporary disabled/commented out "IP Range Assets" step until it's fixed on
+  the API side. It is a known bug and the fix is coming.
+
 ## 1.0.1 - 2022-07-08
 
 ### Changed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -80,7 +80,6 @@ The following entities are created:
 | Certificate | `cycognito_asset_certificate` | `Certificate`         |
 | Domain      | `cycognito_asset_domain`      | `Domain`              |
 | IP          | `cycognito_asset_ip`          | `IpAddress`           |
-| IP Range    | `cycognito_asset_ip_range`    | `Network`             |
 | Issue       | `cycognito_issue`             | `Finding`             |
 | Web App     | `cycognito_asset_web_app`     | `ApplicationEndpoint` |
 
@@ -93,7 +92,6 @@ The following relationships are created:
 | `cycognito_account`           | **HAS**               | `cycognito_asset_certificate` |
 | `cycognito_account`           | **HAS**               | `cycognito_asset_domain`      |
 | `cycognito_account`           | **HAS**               | `cycognito_asset_ip`          |
-| `cycognito_account`           | **HAS**               | `cycognito_asset_ip_range`    |
 | `cycognito_account`           | **HAS**               | `cycognito_asset_web_app`     |
 | `cycognito_account`           | **HAS**               | `cycognito_issue`             |
 | `cycognito_asset_certificate` | **HAS**               | `cycognito_asset_domain`      |

--- a/docs/spec/src/index.ts
+++ b/docs/spec/src/index.ts
@@ -6,7 +6,7 @@ import { ipSpec } from './asset-ip';
 import { domainSpec } from './asset-domain';
 import { certificateSpec } from './asset-certificate';
 import { webAppSpec } from './asset-web-app';
-import { ipRangeSpec } from './asset-ip-range';
+// import { ipRangeSpec } from './asset-ip-range';
 import { issueSpec } from './issue';
 
 export const invocationConfig: IntegrationSpecConfig<IntegrationConfig> = {
@@ -16,7 +16,7 @@ export const invocationConfig: IntegrationSpecConfig<IntegrationConfig> = {
     ...domainSpec,
     ...certificateSpec,
     ...webAppSpec,
-    ...ipRangeSpec,
+    // ...ipRangeSpec,
     ...issueSpec,
   ],
 };

--- a/src/steps/asset-ip-range/index.test.ts
+++ b/src/steps/asset-ip-range/index.test.ts
@@ -1,23 +1,25 @@
-import { executeStepWithDependencies } from '@jupiterone/integration-sdk-testing';
-import { buildStepTestConfigForStep } from '../../../test/config';
-import { Recording, setupProjectRecording } from '../../../test/recording';
-import { IntegrationSteps } from '../constants';
+// import { executeStepWithDependencies } from '@jupiterone/integration-sdk-testing';
+// import { buildStepTestConfigForStep } from '../../../test/config';
+// import { Recording, setupProjectRecording } from '../../../test/recording';
+// import { IntegrationSteps } from '../constants';
 
 // See test/README.md for details
-let recording: Recording;
-afterEach(async () => {
-  await recording.stop();
-});
+// let recording: Recording;
+// afterEach(async () => {
+//   await recording.stop();
+// });
 
-test('fetch-ip-range-assets', async () => {
-  recording = setupProjectRecording({
-    directory: __dirname,
-    name: 'fetch-ip-range-assets',
-  });
+test('fetch-ip-range-assets', () => {
+  // recording = setupProjectRecording({
+  //   directory: __dirname,
+  //   name: 'fetch-ip-range-assets',
+  // });
 
-  const stepConfig = buildStepTestConfigForStep(
-    IntegrationSteps.ASSET_IP_RANGES,
-  );
-  const stepResult = await executeStepWithDependencies(stepConfig);
-  expect(stepResult).toMatchStepMetadata(stepConfig);
+  // const stepConfig = buildStepTestConfigForStep(
+  //   IntegrationSteps.ASSET_IP_RANGES,
+  // );
+  // const stepResult = await executeStepWithDependencies(stepConfig);
+  // expect(stepResult).toMatchStepMetadata(stepConfig);
+
+  expect(1).toBe(1);
 });

--- a/src/steps/asset-ip-range/index.ts
+++ b/src/steps/asset-ip-range/index.ts
@@ -1,53 +1,53 @@
-import {
-  createDirectRelationship,
-  Entity,
-  IntegrationStep,
-  IntegrationStepExecutionContext,
-  RelationshipClass,
-} from '@jupiterone/integration-sdk-core';
+// import {
+//   createDirectRelationship,
+//   Entity,
+//   IntegrationStep,
+//   IntegrationStepExecutionContext,
+//   RelationshipClass,
+// } from '@jupiterone/integration-sdk-core';
 
-import { createAPIClient } from '../../client';
-import { IntegrationConfig } from '../../config';
-import { AssetType, IpRange } from '../../types';
-import {
-  ACCOUNT_ENTITY_KEY,
-  IntegrationSteps,
-  Entities,
-  Relationships,
-} from '../constants';
-import { createIpRangeAssetEntity } from './converter';
+// import { createAPIClient } from '../../client';
+// import { IntegrationConfig } from '../../config';
+// import { AssetType, IpRange } from '../../types';
+// import {
+//   ACCOUNT_ENTITY_KEY,
+//   IntegrationSteps,
+//   Entities,
+//   Relationships,
+// } from '../constants';
+// import { createIpRangeAssetEntity } from './converter';
 
-export async function fetchIpRangeAssetDetails({
-  jobState,
-  instance,
-}: IntegrationStepExecutionContext<IntegrationConfig>) {
-  const apiClient = createAPIClient(instance.config);
+// export async function fetchIpRangeAssetDetails({
+//   jobState,
+//   instance,
+// }: IntegrationStepExecutionContext<IntegrationConfig>) {
+//   const apiClient = createAPIClient(instance.config);
 
-  const accountEntity = (await jobState.getData(ACCOUNT_ENTITY_KEY)) as Entity;
+//   const accountEntity = (await jobState.getData(ACCOUNT_ENTITY_KEY)) as Entity;
 
-  await apiClient.iterateAssets<IpRange>(AssetType.IP_RANGE, async (asset) => {
-    const assetEntity = createIpRangeAssetEntity(asset);
+//   await apiClient.iterateAssets<IpRange>(AssetType.IP_RANGE, async (asset) => {
+//     const assetEntity = createIpRangeAssetEntity(asset);
 
-    await jobState.addEntity(assetEntity);
-    if (accountEntity && assetEntity) {
-      await jobState.addRelationship(
-        createDirectRelationship({
-          _class: RelationshipClass.HAS,
-          from: accountEntity,
-          to: assetEntity,
-        }),
-      );
-    }
-  });
-}
+//     await jobState.addEntity(assetEntity);
+//     if (accountEntity && assetEntity) {
+//       await jobState.addRelationship(
+//         createDirectRelationship({
+//           _class: RelationshipClass.HAS,
+//           from: accountEntity,
+//           to: assetEntity,
+//         }),
+//       );
+//     }
+//   });
+// }
 
-export const IpRangeAssetSteps: IntegrationStep<IntegrationConfig>[] = [
-  {
-    id: IntegrationSteps.ASSET_IP_RANGES,
-    name: 'Fetch IP Range Asset Details',
-    entities: [Entities.ASSET_IP_RANGE],
-    relationships: [Relationships.ACCOUNT_HAS_ASSET_IP_RANGE],
-    dependsOn: [IntegrationSteps.ACCOUNT],
-    executionHandler: fetchIpRangeAssetDetails,
-  },
-];
+// export const IpRangeAssetSteps: IntegrationStep<IntegrationConfig>[] = [
+//   {
+//     id: IntegrationSteps.ASSET_IP_RANGES,
+//     name: 'Fetch IP Range Asset Details',
+//     entities: [Entities.ASSET_IP_RANGE],
+//     relationships: [Relationships.ACCOUNT_HAS_ASSET_IP_RANGE],
+//     dependsOn: [IntegrationSteps.ACCOUNT],
+//     executionHandler: fetchIpRangeAssetDetails,
+//   },
+// ];

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -4,7 +4,7 @@ import { ipAssetSteps } from './asset-ip';
 import { domainAssetSteps } from './asset-domain';
 import { certificateAssetSteps } from './asset-certificate';
 import { webAppAssetSteps } from './asset-web-app';
-import { IpRangeAssetSteps } from './asset-ip-range';
+// import { IpRangeAssetSteps } from './asset-ip-range';
 
 const integrationSteps = [
   ...accountSteps,
@@ -13,7 +13,7 @@ const integrationSteps = [
   ...domainAssetSteps,
   ...certificateAssetSteps,
   ...webAppAssetSteps,
-  ...IpRangeAssetSteps,
+  // ...IpRangeAssetSteps,
 ];
 
 export { integrationSteps };


### PR DESCRIPTION
There is a known bug associated with the IP Range Assets endpoint. Right now it results in 500 error.
The decision was made to comment out this step until it's fixed on the API side and then bring it back.